### PR TITLE
replace Joda-Time with Java Time API for date handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,6 @@
   :managed-dependencies [[org.clojure/clojure "1.12.4"]
                          [org.clojure/tools.logging "1.3.1"]
                          [clj-commons/fs "1.6.312"]
-                         [clj-time "0.15.2"]
                          [commons-io "2.21.0"]
                          [org.bouncycastle/bcpkix-jdk18on "1.83"]
                          [org.bouncycastle/bcpkix-fips "1.0.8"]
@@ -32,7 +31,6 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [clj-commons/fs]
-                 [clj-time]
                  [org.openvoxproject/i18n]
                  [prismatic/schema]]
 

--- a/src/clojure/puppetlabs/ssl_utils/simple.clj
+++ b/src/clojure/puppetlabs/ssl_utils/simple.clj
@@ -1,9 +1,10 @@
 (ns puppetlabs.ssl-utils.simple
   (:import (java.util Date)
+           (java.time Instant)
+           (java.time.temporal ChronoUnit)
            (java.security PublicKey PrivateKey)
            (java.security.cert X509Certificate X509CRL))
   (:require [puppetlabs.ssl-utils.core :as ssl-utils]
-            [clj-time.core :as time]
             [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -70,11 +71,11 @@
    and the dates will be based on the current time. Returns a map in the
    form {:not-before Date :not-after Date}."
   [ca-ttl :- schema/Int]
-  (let [now        (time/now)
-        not-before (time/minus now (time/days 1))
-        not-after  (time/plus now (time/seconds ca-ttl))]
-    {:not-before (.toDate not-before)
-     :not-after  (.toDate not-after)}))
+  (let [now        (Instant/now)
+        not-before (Date/from (.minus now 1 ChronoUnit/DAYS))
+        not-after  (Date/from (.plusSeconds now ca-ttl))]
+    {:not-before not-before
+     :not-after  not-after}))
 
 (def default-keylength
   "The default bit length to use when generating keys.

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -37,7 +37,8 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.PKCSException;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
-import org.joda.time.DateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import javax.net.ssl.CertPathTrustManagerParameters;
 import javax.security.auth.x500.X500Principal;
@@ -356,9 +357,9 @@ public class SSLUtils {
                                       PublicKey issuerPublicKey)
         throws CRLException, IOException, OperatorCreationException, NoSuchAlgorithmException, CertificateEncodingException
     {
-        DateTime now = DateTime.now();
-        Date thisUpdate = now.toDate();
-        Date nextUpdate = now.plusSeconds(crlLifetimeSeconds).toDate();
+        Instant now = Instant.now();
+        Date thisUpdate = Date.from(now);
+        Date nextUpdate = Date.from(now.plusSeconds(crlLifetimeSeconds));
         return generateCRL(issuer, issuerPrivateKey, issuerPublicKey,
                            thisUpdate, nextUpdate, BigInteger.ZERO, null);
     }
@@ -386,9 +387,9 @@ public class SSLUtils {
             throws CRLException {
         // The CRL is not valid if the time of checking == the time of last_update.
         // So to have it valid right now we need to say that it was updated one second ago.
-        DateTime now = DateTime.now();
-        Date thisUpdate = now.minusSeconds(1).toDate();
-        Date nextUpdate = now.plusYears(5).toDate();
+        Instant now = Instant.now();
+        Date thisUpdate = Date.from(now.minusSeconds(1));
+        Date nextUpdate = Date.from(now.plus(5 * 365, ChronoUnit.DAYS));
         X509v2CRLBuilder builder =
                 new JcaX509v2CRLBuilder(crl.getIssuerX500Principal(), thisUpdate);
         builder.setNextUpdate(nextUpdate);
@@ -457,7 +458,7 @@ public class SSLUtils {
             throws CRLException, IOException, NoSuchAlgorithmException, OperatorCreationException {
         X509v2CRLBuilder builder = crlBuilder(crl);
         // TODO PE-5678 Use java.security.cert.CRLReason.KEY_COMPROMISE.ordinal() instead of 1
-        builder.addCRLEntry(serial, DateTime.now().toDate(), 1);
+        builder.addCRLEntry(serial, Date.from(Instant.now()), 1);
         return buildCRL(crl, issuerPrivateKey, issuerPublicKey, builder);
     }
 
@@ -495,7 +496,7 @@ public class SSLUtils {
         X509v2CRLBuilder builder = crlBuilder(crl);
         // TODO PE-5678 Use java.security.cert.CRLReason.KEY_COMPROMISE.ordinal() instead of 1
         for (BigInteger serial : serials) {
-            builder.addCRLEntry(serial, DateTime.now().toDate(), 1);
+            builder.addCRLEntry(serial, Date.from(Instant.now()), 1);
         }
         return buildCRL(crl, issuerPrivateKey, issuerPublicKey, builder);
     }

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -14,8 +14,7 @@
            (javax.net.ssl SSLContext)
            (javax.security.auth.x500 X500Principal)
            (org.bouncycastle.asn1 ASN1Primitive DERUTF8String)
-           (org.bouncycastle.asn1.pkcs Attribute)
-           (org.joda.time DateTimeUtils)))
+           (org.bouncycastle.asn1.pkcs Attribute)))
 
 (def key-id-type-2-byte-length 8)
 
@@ -556,12 +555,9 @@
         (is (= 0 (get-crl-number crl)))
         (is (false? (revoked? crl cert)))
 
-        ;; We need to advance the value of DateTime.now() so it's not the
-        ;; same value that was used when generating the CRL, otherwise it
-        ;; will look like revoke didn't properly advance the dates.
-        ;; This is a consequence of the test generating the CRL and revoking
-        ;; a certificate before the value of DateTime.now() has changed.
-        (DateTimeUtils/setCurrentMillisOffset 9999)
+        ;; We need to advance the wall clock so the revoked CRL's thisUpdate
+        ;; is strictly after the original CRL's thisUpdate.
+        (Thread/sleep 10)
         (let [updated-crl (revoke crl private-key public-key (get-serial cert))]
           (testing "certificate is revoked"
             (is (true? (revoked? updated-crl cert))))

--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -5,7 +5,9 @@
            (javax.security.auth.x500 X500Principal)
            (org.bouncycastle.asn1.x500 X500Name)
            (org.bouncycastle.pkcs PKCS10CertificationRequest)
-           (org.joda.time DateTime Period)
+           (java.time Instant)
+           (java.time.temporal ChronoUnit)
+           (java.util Date)
            (org.bouncycastle.asn1.x509 SubjectPublicKeyInfo)
            (com.puppetlabs.ssl_utils SSLUtils))
   (:require [clojure.test :refer :all]
@@ -77,17 +79,13 @@
   (issued-by? x (str x500-name)))
 
 (defn generate-past-date []
-  (-> (DateTime/now)
-      (.minus (Period/days 1))
-      (.toDate)))
+  (Date/from (.minus (Instant/now) 1 ChronoUnit/DAYS)))
 
 (defn generate-not-before-date []
   (generate-past-date))
 
 (defn generate-future-date []
-  (-> (DateTime/now)
-      (.plus (Period/years 5))
-      (.toDate)))
+  (Date/from (.plus (Instant/now) (* 5 365) ChronoUnit/DAYS)))
 
 (defn generate-not-after-date []
   (generate-future-date))
@@ -100,7 +98,7 @@
 (defn generate-expired-crl
   [issuer issuer-private-key issuer-public-key]
   (SSLUtils/generateCRL issuer issuer-private-key issuer-public-key
-                        (.toDate (DateTime/now))
+                        (Date/from (Instant/now))
                         (generate-past-date)
                         BigInteger/ZERO
                         nil))
@@ -116,7 +114,7 @@
 (defn generate-newer-crl
   [issuer issuer-private-key issuer-public-key]
   (SSLUtils/generateCRL issuer issuer-private-key issuer-public-key
-                        (.toDate (DateTime/now))
+                        (Date/from (Instant/now))
                         (generate-future-date)
                         BigInteger/ONE
                         nil))
@@ -124,7 +122,7 @@
 (defn generate-newest-crl
   [issuer issuer-private-key issuer-public-key]
   (SSLUtils/generateCRL issuer issuer-private-key issuer-public-key
-                        (.toDate (DateTime/now))
+                        (Date/from (Instant/now))
                         (generate-future-date)
                         BigInteger/TEN
                         nil))
@@ -134,7 +132,7 @@
 (defn generate-delta-crl
   [issuer issuer-private-key issuer-public-key]
   (SSLUtils/generateCRL issuer issuer-private-key issuer-public-key
-                        (.toDate (DateTime/now))
+                        (Date/from (Instant/now))
                         (generate-future-date)
                         BigInteger/ONE
                         [(javaize (delta-crl-indicator BigInteger/ZERO))]))


### PR DESCRIPTION
- remove clj-time dependency (which was being used only to bring in Joda-Time transitively)