### PR TITLE
Update test matrix to include FIPS

### DIFF
--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -16,7 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        fips: ['fips-disabled']
         version: ['17', '21', '25']
+        # Add additional coverage for FIPS. Only Java 17 is tested as
+        # that is the only JVM version that bc-fips 1.x is certified for.
+        include:
+          - fips: 'fips-enabled'
+            version: '17'
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
@@ -45,7 +51,9 @@ jobs:
           java -version
           lein eastwood
       - name: clojure tests
-        run: lein test
+        env:
+          LEIN_PROFILE: ${{ case(matrix.fips == 'fips-enabled', 'fips', 'dev') }}
+        run: lein with-profile $LEIN_PROFILE test
         timeout-minutes: 30
 
   tests:

--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -56,6 +56,6 @@ jobs:
     name: Test suite
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -468,8 +468,11 @@
               1 not-before not-after
               issuer-name public-key
               (create-ca-extensions issuer-name 1 public-key))
+        [crl-this-update crl-next-update] (generate-past-crl-dates)
         crl (generate-crl (X500Principal. issuer-name)
-                          private-key public-key)]
+                          private-key public-key
+                          crl-this-update crl-next-update
+                          BigInteger/ZERO [])]
 
     (testing "create CRL"
       (is (= key-id-type-1-byte-length (-> (get-extension-value crl authority-key-identifier-oid)
@@ -555,9 +558,6 @@
         (is (= 0 (get-crl-number crl)))
         (is (false? (revoked? crl cert)))
 
-        ;; We need to advance the wall clock so the revoked CRL's thisUpdate
-        ;; is strictly after the original CRL's thisUpdate.
-        (Thread/sleep 10)
         (let [updated-crl (revoke crl private-key public-key (get-serial cert))]
           (testing "certificate is revoked"
             (is (true? (revoked? updated-crl cert))))

--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -86,6 +86,17 @@
 (defn generate-future-date []
   (Date/from (.plus (Instant/now) (* 5 365) ChronoUnit/DAYS)))
 
+(defn generate-past-crl-dates
+  "Returns a [thisUpdate nextUpdate] pair anchored one day in the past, for
+  generating a CRL whose dates are guaranteed to be strictly earlier than
+  those of any CRL revised 'now' (e.g. by revoke). CRL dates have one-second
+  ASN.1 resolution and revoke backdates thisUpdate by a second, so a CRL
+  generated with 'now' dates can tie or beat its own revision."
+  []
+  (let [this-update (.minus (Instant/now) 1 ChronoUnit/DAYS)]
+    [(Date/from this-update)
+     (Date/from (.plus this-update (* 5 365) ChronoUnit/DAYS))]))
+
 (defn generate-not-after-date []
   (generate-future-date))
 


### PR DESCRIPTION
### Short description

This changeset pins GitHub Actions, updates the test suite with a cell that exercises Java 17 in FIPS mode, and fixes a flaky test that asserted changes in CRL dates.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
