### PR TITLE
Upgrade BouncyCastle 1.84->1.85

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
   :managed-dependencies [[org.clojure/clojure "1.12.5"]
                          [org.clojure/tools.logging "1.3.1"]
                          [commons-io "2.22.0"]
-                         [org.bouncycastle/bcpkix-jdk18on "1.84"]
+                         [org.bouncycastle/bcpkix-jdk18on "1.85"]
                          [org.bouncycastle/bcpkix-fips "1.0.8"]
                          [org.bouncycastle/bc-fips "1.0.2.6"]
                          [org.bouncycastle/bctls-fips "1.0.19"]

--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -6,9 +6,8 @@
            (org.bouncycastle.asn1.x500 X500Name)
            (org.bouncycastle.pkcs PKCS10CertificationRequest)
            (com.puppetlabs.ssl_utils ExtensionsUtils$AttributeDescriptor SSLUtils
-                                     ExtensionsUtils)
+                                     ExtensionsUtils PuppetCNStyle)
            (java.util Map List Date Set)
-           (org.bouncycastle.asn1.x500.style BCStyle)
            (org.bouncycastle.openssl.jcajce JcaPEMWriter)
            (java.io InputStream File Reader BufferedReader Writer OutputStream BufferedWriter)
            (java.net URI URL Socket))
@@ -28,7 +27,7 @@
   ;; TODO: Maybe using a string parsing algo is faster?
   [x]
   (try
-    (X500Name. BCStyle/INSTANCE x)
+    (X500Name. PuppetCNStyle/INSTANCE x)
     (not (nil? x))
     (catch Exception _
       false)))

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -841,7 +841,7 @@ public class ExtensionsUtils {
                                                               BigInteger serialNumber)
         throws OperatorCreationException {
         GeneralNames issuerAsGeneralNames =
-            new GeneralNames(new GeneralName(new X500Name(issuer)));
+            new GeneralNames(new GeneralName(new X500Name(PuppetCNStyle.INSTANCE, issuer)));
         if (authorityKeyId != null) {
             return new AuthorityKeyIdentifier(authorityKeyId.getKeyIdentifier(),
                                                         issuerAsGeneralNames,

--- a/src/java/com/puppetlabs/ssl_utils/PuppetCNStyle.java
+++ b/src/java/com/puppetlabs/ssl_utils/PuppetCNStyle.java
@@ -1,0 +1,55 @@
+package com.puppetlabs.ssl_utils;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.x500.X500NameStyle;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+
+/**
+ * BCStyle subclass that does not enforce the RFC 5280 upper bound
+ *
+ * BouncyCastle 1.85 started enforcing the 64 character limit on
+ * Common Name fields. This presents a problem for Puppet certificate
+ * usage as the CN is usually populated with the Fully Qualified
+ * Domain Name of a node, which DNS allows to be up to 253 characters.
+ *
+ * Some usages can push past that, for example the default CA subject
+ * of:
+ *
+ *   Puppet CA: $fqdn
+ *
+ * For now, this class implements the relaxed behavior of BouncyCastle
+ * 1.84. It may gain a 253 character limit in the near future, and
+ * may disappear entirely in the far future if a method to preserve
+ * `certname` semantics is found while also complying with the
+ * RFC 5280 limit.
+ *
+ * @see https://github.com/bcgit/bc-java/commit/a6ae24643e7ba7cfdf9267656ce83bb656ab9777
+ */
+public class PuppetCNStyle extends BCStyle {
+  public static final X500NameStyle INSTANCE = new PuppetCNStyle();
+
+  protected PuppetCNStyle() { }
+
+  @Override
+  protected ASN1Encodable encodeStringValue(ASN1ObjectIdentifier oid, String value) {
+    // When using the FIPS libraries, ASN1ObjectIdentifier.equals()
+    // is not implemented. So, cast to string and compare against
+    // the OID value for Common Name (CN).
+    if (oid.toString().equals("2.5.4.3")) {
+      // TODO: throw IllegalArgumentException if CN is longer than 253
+      //       characters. Breaking change. Requires a major version bump.
+
+      // encode directly, bypassing BCStyle's 64-char cap; a CN is a
+      // DirectoryString, and BC's default DirectoryString encoding is
+      // a UTF8String (as done by AbstractX500NameStyle for all other
+      // string-valued attributes).
+      return new DERUTF8String(value);
+    }
+
+    // every other attribute keeps the standard BCStyle behaviour,
+    // including the country-code and other DirectoryString bounds.
+    return super.encodeStringValue(oid, value);
+  }
+}

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -164,7 +164,7 @@ public class SSLUtils {
      * @return The common name from the X500Name.  Empty string if none available.
      */
     public static String getCommonNameFromX500Name(String x500Name) {
-        RDN[] rdns = new X500Name(BCStyle.INSTANCE, x500Name).getRDNs(BCStyle.CN);
+        RDN[] rdns = new X500Name(PuppetCNStyle.INSTANCE, x500Name).getRDNs(BCStyle.CN);
         String commonName = "";
         if (rdns.length > 0) {
             AttributeTypeAndValue attributeInfo = rdns[0].getFirst();
@@ -196,7 +196,7 @@ public class SSLUtils {
         // TODO: the puppet code sets a property "version=0" on the request object
         // here; can't figure out how to do that at the moment.  Not sure if it's needed.
         PKCS10CertificationRequestBuilder requestBuilder =
-                new JcaPKCS10CertificationRequestBuilder(new X500Name(BCStyle.INSTANCE, subjectDN), keyPair.getPublic());
+                new JcaPKCS10CertificationRequestBuilder(new X500Name(PuppetCNStyle.INSTANCE, subjectDN), keyPair.getPublic());
 
         if ((extensions != null) && (extensions.size() > 0)) {
             Extensions parsedExts = ExtensionsUtils.getExtensionsObjFromMap(extensions);
@@ -264,11 +264,11 @@ public class SSLUtils {
             throws IOException, OperatorCreationException, CertificateException
     {
         X509v3CertificateBuilder certBuilder = new X509v3CertificateBuilder(
-                new X500Name(BCStyle.INSTANCE, issuerDn),
+                new X500Name(PuppetCNStyle.INSTANCE, issuerDn),
                 serialNumber,
                 notBefore,
                 notAfter,
-                new X500Name(BCStyle.INSTANCE, subjectDn),
+                new X500Name(PuppetCNStyle.INSTANCE, subjectDn),
                 SubjectPublicKeyInfo.getInstance(subjectPublicKey.getEncoded()));
 
         Extensions bcExtensions = ExtensionsUtils.getExtensionsObjFromMap(extensions);
@@ -1349,7 +1349,7 @@ public class SSLUtils {
     public static String getSubjectFromX509Certificate(X509Certificate certificate) {
         byte[] encodedName = certificate.getSubjectX500Principal().getEncoded();
         X500Name x500Name = X500Name.getInstance(encodedName);
-        return BCStyle.INSTANCE.toString(x500Name);
+        return PuppetCNStyle.INSTANCE.toString(x500Name);
     }
 
     /**
@@ -1411,14 +1411,14 @@ public class SSLUtils {
                     "The RDN pairs list must contain an even number of elements.");
         }
 
-        X500NameBuilder builder = new X500NameBuilder(BCStyle.INSTANCE);
+        X500NameBuilder builder = new X500NameBuilder(PuppetCNStyle.INSTANCE);
 
         for (int i=0; i < rdnPairs.size(); i++) {
             String attr = rdnPairs.get(i);
             i++;
             String val = rdnPairs.get(i);
 
-            builder.addRDN(BCStyle.INSTANCE.attrNameToOID(attr), val);
+            builder.addRDN(PuppetCNStyle.INSTANCE.attrNameToOID(attr), val);
         }
 
         return builder.build().toString();
@@ -1431,7 +1431,7 @@ public class SSLUtils {
      * @return The RDN form of the common name.
      */
     public static String x500NameCn(String commonName) {
-        return new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, commonName).build().toString();
+        return new X500NameBuilder(PuppetCNStyle.INSTANCE).addRDN(BCStyle.CN, commonName).build().toString();
     }
 
     /**

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -128,6 +128,65 @@
                                         (get-public-key key-pair))]
       (is (= subject (get-subject-from-x509-certificate certificate))))))
 
+(deftest long-puppet-common-name-test
+  (let [long-dn (str "CN=" long-puppet-cn)]
+    (testing "valid-x500-name? accepts a CN longer than 64 characters"
+      (is (valid-x500-name? long-dn)))
+
+    (testing "create X500 RDN from a long common name"
+      (is (= long-dn (cn long-puppet-cn))))
+
+    (testing "create X500 DN containing a long common name"
+      (is (= (str long-dn ",O=org") (dn [:cn long-puppet-cn :o "org"]))))
+
+    (testing "long cn extracted from an X500 name"
+      (is (= long-puppet-cn (x500-name->CN long-dn))))
+
+    (testing "long cn extracted from an X500Principal"
+      (is (= long-puppet-cn (get-cn-from-x500-principal (X500Principal. long-dn)))))
+
+    ;; The constructor call in each block below sits inside its own `is` so
+    ;; that when it throws, the block reports a single error and the remaining
+    ;; blocks still run, instead of the exception aborting the whole deftest.
+    (testing "create CSR with a long CN in the subject"
+      (let [csr (is (generate-certificate-request (generate-key-pair 512) long-dn))]
+        (when csr
+          (is (certificate-request? csr))
+          (is (has-subject? csr long-dn)))))
+
+    (testing "sign certificate with a long CN in the subject and issuer"
+      (let [key-pair (generate-key-pair 512)
+            certificate (is (sign-certificate long-dn
+                                              (get-private-key key-pair)
+                                              42
+                                              (generate-not-before-date)
+                                              (generate-not-after-date)
+                                              long-dn
+                                              (get-public-key key-pair)))]
+        (when certificate
+          (is (certificate? certificate))
+          (is (has-subject? certificate long-dn))
+          (is (issued-by? certificate long-dn))
+          (is (= long-puppet-cn (get-cn-from-x509-certificate certificate)))
+          (is (= long-dn (get-subject-from-x509-certificate certificate))))))
+
+    (testing "sign certificate with a long CN in the issuer DN of its authority key identifier"
+      (let [key-pair (generate-key-pair 512)
+            extensions [(authority-key-identifier-options long-dn 42 false)]
+            certificate (is (sign-certificate (cn "my ca")
+                                              (get-private-key key-pair)
+                                              42
+                                              (generate-not-before-date)
+                                              (generate-not-after-date)
+                                              (cn "foo")
+                                              (get-public-key key-pair)
+                                              extensions))]
+        (when certificate
+          (is (certificate? certificate))
+          (is (= [long-dn]
+                 (get-in (get-extension-value certificate authority-key-identifier-oid)
+                         [:issuer :directory-name]))))))))
+
 (deftest certification-request-test
   (testing "create CSR"
     (let [subject (cn "subject")

--- a/test/puppetlabs/ssl_utils/simple_test.clj
+++ b/test/puppetlabs/ssl_utils/simple_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.ssl-utils.simple-test
   (:require [clojure.test :refer :all]
             [puppetlabs.ssl-utils.simple :as simple]
-            [puppetlabs.ssl-utils.core :as ssl-utils])
+            [puppetlabs.ssl-utils.core :as ssl-utils]
+            [puppetlabs.ssl-utils.testutils :as testutils])
   (:import (java.io ByteArrayOutputStream ByteArrayInputStream)))
 
 (defn roundtrip-pem
@@ -26,6 +27,26 @@
       (is (= "foo.localdomain" (ssl-utils/get-cn-from-x509-certificate read-cert)))
       (is (= "ca" (ssl-utils/get-cn-from-x500-principal (.getIssuerX500Principal read-cert))))
       (is (= "ca" (ssl-utils/get-cn-from-x500-principal (.getIssuerX500Principal read-crl)))))))
+
+(deftest long-puppet-common-name-test
+  (testing "certnames longer than the RFC 5280 CN bound of 64 characters work through the simple API"
+    ;; Each generation step sits inside its own `is` so that when it throws,
+    ;; it reports a single error and the remaining steps still run, instead
+    ;; of the exception aborting the whole deftest.
+    (let [long-certname testutils/long-puppet-cn
+          ca-cert (is (simple/gen-self-signed-cert long-certname 1 {:keylength 512} true))
+          cert (when ca-cert
+                 (is (simple/gen-cert long-certname ca-cert 2 {:keylength 512})))
+          crl (when ca-cert
+                (is (simple/gen-crl ca-cert)))]
+      (when ca-cert
+        (is (simple/ssl-cert? ca-cert))
+        (is (= long-certname (ssl-utils/get-cn-from-x509-certificate (:cert ca-cert)))))
+      (when cert
+        (is (simple/ssl-cert? cert))
+        (is (= long-certname (ssl-utils/get-cn-from-x509-certificate (:cert cert)))))
+      (when crl
+        (is (ssl-utils/certificate-revocation-list? crl))))))
 
 (deftest optional-parameters-test
   (testing "Can specify keylength when generating a certificate"

--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -14,6 +14,16 @@
             [clojure.java.io :as io :refer [resource]]
             [puppetlabs.ssl-utils.core :refer :all]))
 
+(def long-puppet-cn
+  "For decades, the Puppet agent has set the CN= field of requested Certificates
+  to the FQDN of the node the agent runs on. DNS allows this to be up to 253
+  characters, which is more than the 64 characters that RFC 5280 allows for a
+  CN.
+
+  Thus, for backwards compatbility with existing agent populations, we have to
+  test that we can break with the spec."
+  "puppet-cns.are-usually-fqdns.which-can-be-longer-than-rfc5280-allows.test")
+
 (defn pubkey-sha1
   "Gets the SHA-1 digest of the raw bytes of the provided publickey."
   [pub-key]


### PR DESCRIPTION
### Short description

RFC 5280 specifies that the Common Name, or CN, of an X500 object should
not be more than 64 characters. BouncyCastle recently started enforcing
this limit in the 1.85 release.

Unfortunately, this runs afoul of long-standing legacy in Puppet
certificate use: the CN defaults to the FDQN of a node and the limit
imposed by DNS for the length of this string is 253 characters.

This commit follows an official example from BouncyCastle upstream for
overriding the new 64 character limit by introducing a `PuppetCNStyle`
class and using it instead of the BouncyCastle `BCStyle` that enforces
the limit.

See: https://github.com/bcgit/bc-java/issues/750
See: https://github.com/bcgit/bc-java/commit/a6ae24643e7ba7cfdf9267656ce83bb656ab9777
See: https://web.archive.org/web/20190518124533/https://devblogs.microsoft.com/oldnewthing/?p=7873

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
